### PR TITLE
install jitterentropy-rngd by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Depends:
     gnome-terminal,
     gnome-themes-standard,
     haveged,
+    jitterentropy-rngd,
     libnotify-bin,
     locales,
     locales-all,


### PR DESCRIPTION
Add `jitterentropy-rngd` as `Depends:` to package `qubes-vm-recommended`.