### PR TITLE
Arch: avoid relying on “qubes-vm-qrexec” package

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -35,7 +35,7 @@ build() {
 }
 
 package_qubes-vm-dependencies() {
-    depends=(qubes-vm-xen qubes-vm-core qubes-vm-qrexec qubes-vm-gui qubes-vm-pulseaudio)
+    depends=(qubes-vm-xen qubes-vm-core qubes-vm-gui qubes-vm-pulseaudio)
 }
 
 package_qubes-vm-recommended() {


### PR DESCRIPTION
It doesn’t exist on Arch.

Part of QubesOS/qubes-issues#6327.