### PR TITLE
spec: disable pdf-converter for CentOS

### DIFF
--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -46,7 +46,7 @@ Requires:   qubes-usb-proxy
 Requires:   thunderbird-qubes
 # qubes-pdf-converter needs python3.7+ currently
 # not fully available
-%if 0%{?rhel} != 7
+%if ! (0%{?rhel} && 0%{?rhel} <= 8)
 Requires:   qubes-pdf-converter
 %endif
 


### PR DESCRIPTION
We step back from maintaining python3.8 extra repository