### PR TITLE
Thunderbird extension doesn’t actually work

### DIFF
--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -43,7 +43,6 @@ Requires:   qubes-img-converter
 Requires:   qubes-input-proxy-sender
 Requires:   qubes-mgmt-salt-vm-connector
 Requires:   qubes-usb-proxy
-Requires:   thunderbird-qubes
 # qubes-pdf-converter needs python3.7+ currently
 # not fully available
 %if ! (0%{?rhel} && 0%{?rhel} <= 8)


### PR DESCRIPTION
Right now, `thunderbird-qubes` doesn’t actually work, so `qubes-vm-recommended` should not depend on it.