### PR TITLE
remove annobin as required for dom0

### DIFF
--- a/comps/comps-dom0.xml
+++ b/comps/comps-dom0.xml
@@ -121,7 +121,6 @@
       <packagereq type="mandatory">which</packagereq>
       <packagereq type="mandatory">dnf-utils</packagereq>
       <packagereq type="mandatory">zip</packagereq>
-      <packagereq type="mandatory">annobin</packagereq>
       <packagereq type="mandatory">authselect</packagereq>
     </packagelist>
   </group>


### PR DESCRIPTION
This will prevent the installation dev packages and save about 160M