### PR TITLE
Don’t require qubes-thunderbird on Debian, either

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,6 @@ Depends:
     qubes-input-proxy-sender,
     qubes-mgmt-salt-vm-connector,
     qubes-pdf-converter,
-    qubes-thunderbird,
     qubes-usb-proxy
 Description: Meta package with packages recommended in Qubes VM
  Installing this package is recommended to have full functionality available in


### PR DESCRIPTION
It doesn’t work on Debian either and should not be required.