### PR TITLE
Remove packages that need rpm to build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Architecture: any
 Depends:
     xfce4-notifyd,
     pulseaudio-qubes,
-    qubes-core-agent-dom0-updates,
     qubes-core-agent-nautilus,
     qubes-core-agent-network-manager,
     qubes-core-agent-networking,
@@ -41,7 +40,6 @@ Depends:
     qubes-gpg-split,
     qubes-img-converter,
     qubes-input-proxy-sender,
-    qubes-mgmt-salt-vm-connector,
     qubes-pdf-converter,
     qubes-usb-proxy
 Description: Meta package with packages recommended in Qubes VM


### PR DESCRIPTION
Removing these 2 packages from the dependencies is required for debian/focal (non-rpm) templates to build.

ref: https://forum.qubes-os.org/t/ubuntu-focal-template-not-building/5511