### PR TITLE
Remove deps from debian that will not work

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -8,9 +8,11 @@ DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
 # remove Debian dependencies that will not work in Ubuntu focal
-ifeq ($(DIST),focal)
-  sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control
-  sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control
-endif
+source-debian-quilt-copy-in:
+	if [[ $(DIST) == focal ]] ; then \
+            sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+            sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+	fi
+
 
 # vim: filetype=make

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,6 +7,10 @@ RPM_SPEC_FILES := $(RPM_SPEC_FILES.$(PACKAGE_SET))
 DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
+ifneq (,$(findstring $(DISTRIBUTION),qubuntu))
+  SOURCE_COPY_IN := source-debian-quilt-copy-in
+endif
+
 # remove Debian dependencies that will not work in Ubuntu focal
 source-debian-quilt-copy-in:
 	if [[ $(DIST) == focal ]] ; then \

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,4 +7,10 @@ RPM_SPEC_FILES := $(RPM_SPEC_FILES.$(PACKAGE_SET))
 DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
+# remove Debian dependencies that will not work in Ubuntu focal
+if [[ $(DIST) == focal ]] ; then \
+    sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+    sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+fi
+
 # vim: filetype=make

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -8,9 +8,9 @@ DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
 # remove Debian dependencies that will not work in Ubuntu focal
-if [[ $(DIST) == focal ]] ; then \
-    sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-    sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-fi
+ifeq ($(DIST),focal)
+  sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control
+  sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control
+endif
 
 # vim: filetype=make

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Architecture: any
 Depends:
     xfce4-notifyd,
     pulseaudio-qubes,
-    qubes-core-agent-dom0-updates,
     qubes-core-agent-nautilus,
     qubes-core-agent-network-manager,
     qubes-core-agent-networking,
@@ -41,7 +40,6 @@ Depends:
     qubes-gpg-split,
     qubes-img-converter,
     qubes-input-proxy-sender,
-    qubes-mgmt-salt-vm-connector,
     qubes-pdf-converter,
     qubes-usb-proxy
 Description: Meta package with packages recommended in Qubes VM

--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Architecture: any
 Depends:
     xfce4-notifyd,
     pulseaudio-qubes,
+    qubes-core-agent-dom0-updates,
     qubes-core-agent-nautilus,
     qubes-core-agent-network-manager,
     qubes-core-agent-networking,
@@ -40,6 +41,7 @@ Depends:
     qubes-gpg-split,
     qubes-img-converter,
     qubes-input-proxy-sender,
+    qubes-mgmt-salt-vm-connector,
     qubes-pdf-converter,
     qubes-usb-proxy
 Description: Meta package with packages recommended in Qubes VM


### PR DESCRIPTION
removed qubes-core-agent-dom0-updates and qubes-mgmt-salt-vm-connector from debian build deps. They require rpm.

ref: https://forum.qubes-os.org/t/ubuntu-focal-template-not-building/5511