### PR TITLE
Remove Debian dependencies that will not work in bookworm

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,14 +7,17 @@ RPM_SPEC_FILES := $(RPM_SPEC_FILES.$(PACKAGE_SET))
 DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
-ifneq (,$(findstring $(DISTRIBUTION),qubuntu))
+ifneq (,$(findstring $(DISTRIBUTION),debian qubuntu))
   SOURCE_COPY_IN := source-debian-quilt-copy-in
 endif
 
-# remove Debian dependencies that will not work in Ubuntu focal
+# remove Debian dependencies that will not work in Ubuntu focal and bookworm
 source-debian-quilt-copy-in:
 	if [[ $(DIST) == focal ]] ; then \
             sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+            sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
+	fi
+	if [[ $(DIST) == bookworm ]] ; then \
             sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
 	fi
 


### PR DESCRIPTION
salt-ssh is not (yet?) available in bookworm
