### PR TITLE
rpm: Use conditional dependencies

### DIFF
--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -32,10 +32,10 @@ This package depends on packages required to be installed in Qubes VM.
 %package -n qubes-vm-recommended
 Summary:    Meta package with packages recommended in Qubes VM
 Requires:   xfce4-notifyd
-Requires:   pulseaudio-qubes
+Requires:   (pulseaudio-qubes if pulseaudio)
 Requires:   qubes-core-agent-dom0-updates
-Requires:   qubes-core-agent-nautilus
-Requires:   qubes-core-agent-network-manager
+Requires:   (qubes-core-agent-nautilus if nautilus)
+Requires:   (qubes-core-agent-network-manager if NetworkManager)
 Requires:   qubes-core-agent-networking
 Requires:   qubes-core-agent-passwordless-root
 Requires:   qubes-gpg-split

--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -35,6 +35,7 @@ Requires:   xfce4-notifyd
 Requires:   (pulseaudio-qubes if pulseaudio)
 Requires:   qubes-core-agent-dom0-updates
 Requires:   (qubes-core-agent-nautilus if nautilus)
+Requires:   (qubes-core-agent-thunar if Thunar)
 Requires:   (qubes-core-agent-network-manager if NetworkManager)
 Requires:   qubes-core-agent-networking
 Requires:   qubes-core-agent-passwordless-root


### PR DESCRIPTION
Do not force installing qubes integration for software that isn't
installed, and also do not pull in all the software that qubes
integration exists for.