### PR TITLE
Changes for R4.2

### DIFF
--- a/comps/comps-dom0.xml
+++ b/comps/comps-dom0.xml
@@ -1411,6 +1411,7 @@
       <packagereq type="default">qubes-pdf-converter-dom0</packagereq>
       <packagereq type="default">qubes-usb-proxy-dom0</packagereq>
       <packagereq type="default">libvirt-client</packagereq>
+      <packagereq type="default">qubes-dom0-unwanted-packages</packagereq>
       <!--
       We add 'kernel-latest' and 'kernel-latest-qubes-vm' only as
       optional because it is not included in stable official releases

--- a/comps/comps-dom0.xml
+++ b/comps/comps-dom0.xml
@@ -1404,6 +1404,7 @@
       <packagereq type="mandatory">qubes-manager</packagereq>S
       <packagereq type="mandatory">qubes-mgmt-salt-dom0</packagereq>
       <packagereq type="mandatory">qubes-dom0-meta-packages</packagereq>
+      <packagereq type="mandatory">qubes-desktop-linux-menu</packagereq>
       <packagereq type="default">qubes-gpg-split-dom0</packagereq>
       <packagereq type="default">qubes-img-converter-dom0</packagereq>
       <packagereq type="default">qubes-input-proxy</packagereq>

--- a/rpm_spec/qubes-dom0-meta-packages.spec.in
+++ b/rpm_spec/qubes-dom0-meta-packages.spec.in
@@ -23,6 +23,14 @@ Summary: Repository definition for packages contributed to Qubes OS
 Contrib repository contains packages written/adopted specifically for Qubes,
 not available in upstream repositories.
 
+%package -n qubes-dom0-unwanted-packages
+Summary: Prevents installing unwanted dom0 packages
+# gtk3 Recommends: tracker-miner, avoid installing the whole thing
+Conflicts: tracker
+
+%description -n qubes-dom0-unwanted-packages
+Conflicts or dummy provides packages that are not wanted in dom0.
+
 %prep
 %setup -q
 
@@ -43,6 +51,8 @@ make -C repos install-dom0 DESTDIR=$RPM_BUILD_ROOT
 %config(noreplace) /etc/yum.repos.d/qubes-contrib-dom0-r4.1.repo
 /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4.1-contrib-fedora
 /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-fedora
+
+%files -n qubes-dom0-unwanted-packages
 
 %posttrans -n qubes-repo-contrib
 systemd-run --on-active=5min rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-fedora


### PR DESCRIPTION
- install the new menu by default (QubesOS/qubes-issues#7939)
- prevent installing 'tracker'