### PR TITLE
Restore salt on bookworm, fix logic re ubuntu focal

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -11,7 +11,6 @@ vm:
     - debian
     source:
       commands:
-      - 'sed -i /qubes-mgmt-salt-vm-connector/d @SOURCE_DIR@/debian/control'
       - 'sed -i "s/pulseaudio-qubes,/pipewire-qubes,/" @SOURCE_DIR@/debian/control'
   archlinux:
     build:
@@ -21,15 +20,15 @@ vm:
       build:
       - debian
       source:
-        commands:
-        - 'sed -i /qubes-mgmt-salt-vm-connector/d @SOURCE_DIR@/debian/control'
+        commands: []
 
 vm-focal:
   deb:
     build:
     - debian
     source:
-      commands: []
+      commands:
+      - 'sed -i /qubes-mgmt-salt-vm-connector/d @SOURCE_DIR@/debian/control'
 
 vm-bullseye:
   deb:

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,17 +7,14 @@ RPM_SPEC_FILES := $(RPM_SPEC_FILES.$(PACKAGE_SET))
 DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
-ifneq (,$(findstring $(DISTRIBUTION),debian qubuntu))
+ifneq (,$(findstring $(DISTRIBUTION),qubuntu))
   SOURCE_COPY_IN := source-debian-quilt-copy-in
 endif
 
-# remove Debian dependencies that will not work in Ubuntu focal and bookworm
+# remove Debian dependencies that will not work in Ubuntu focal
 source-debian-quilt-copy-in:
 	if [[ $(DIST) == focal ]] ; then \
             sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-            sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-	fi
-	if [[ $(DIST) == bookworm ]] ; then \
             sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
 	fi
 


### PR DESCRIPTION
We do maintain own salt package for bookworm now.

For focal, salt was supposed to be excluded, but the actual code did the
opposite - included it only on focal (but not other Ubuntu versions).
Fix this too, while at it.

This reverts commit d06e436301168e39d1643274154619447be3f9af and
5a0d9e5c61f8423a1a5c5d5e1cf039f228449dbc.