### PR TITLE
debian: use dynamic variables instead of patching control file

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -9,30 +9,6 @@ vm:
   deb:
     build:
     - debian
-    source:
-      commands:
-      - 'sed -i "s/pulseaudio-qubes,/pipewire-qubes,/" @SOURCE_DIR@/debian/control'
   archlinux:
     build:
     - archlinux
-  ubuntu:
-    deb:
-      build:
-      - debian
-      source:
-        commands: []
-
-vm-focal:
-  deb:
-    build:
-    - debian
-    source:
-      commands:
-      - 'sed -i /qubes-mgmt-salt-vm-connector/d @SOURCE_DIR@/debian/control'
-
-vm-bullseye:
-  deb:
-    build:
-    - debian
-    source:
-      commands: []

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,20 +7,6 @@ RPM_SPEC_FILES := $(RPM_SPEC_FILES.$(PACKAGE_SET))
 DEBIAN_BUILD_DIRS := $(DEBIAN_BUILD_DIRS.$(PACKAGE_SET))
 ARCH_BUILD_DIRS := $(ARCH_BUILD_DIRS.$(PACKAGE_SET))
 
-ifneq (,$(findstring $(DISTRIBUTION),qubuntu debian))
-  SOURCE_COPY_IN := source-debian-quilt-copy-in
-endif
-
-# remove Debian dependencies that will not work in Ubuntu focal
-source-debian-quilt-copy-in:
-	if [[ $(DIST) == focal ]] ; then \
-            sed -i /qubes-core-agent-dom0-updates/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-            sed -i /qubes-mgmt-salt-vm-connector/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-	fi
-	if [[ $(DIST) != bullseye ]] && [[ $(DIST) != focal ]] && [[ $(DIST) != jammy ]]; then \
-	        sed -i "s/pulseaudio-qubes,/pipewire-qubes,/" $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-	fi
-
 # Support for new packaging
 ifneq ($(filter $(DISTRIBUTION), archlinux),)
 VERSION := $(file <$(ORIG_SRC)/$(DIST_SRC)/version)

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Package: qubes-vm-recommended
 Architecture: any
 Depends:
     xfce4-notifyd,
-    pulseaudio-qubes,
+    ${pulse:Depends},
     qubes-core-agent-dom0-updates,
     qubes-core-agent-nautilus,
     qubes-core-agent-network-manager,
@@ -41,7 +41,7 @@ Depends:
     qubes-gpg-split,
     qubes-img-converter,
     qubes-input-proxy-sender,
-    qubes-mgmt-salt-vm-connector,
+    ${qubessalt:Depends},
     qubes-pdf-converter,
     qubes-usb-proxy,
     fwupd-qubes-vm,

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,8 @@
 include /usr/share/dpkg/default.mk
 export DESTDIR=$(shell pwd)/debian/tmp
 
+DIST := $(shell grep ^VERSION_CODENAME= /etc/os-release | cut -d = -f 2)
+
 %:
 	dh $@
 
@@ -14,3 +16,16 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	make -C repos install-vm-debian
+
+override_dh_gencontrol:
+	echo "dist: $(DIST)"
+	if [ "$(DIST)" != "focal" ]; then \
+		echo "qubessalt:Depends=qubes-mgmt-salt-vm-connector" \
+			>> debian/qubes-vm-recommended.substvars; \
+	fi
+	if [ "$(DIST)" != "bullseye" ] && [ "$(DIST)" != "jammy" ] && [ "$(DIST)" != "focal" ]; then \
+		echo "pulse:Depends=pipewire-qubes" >> debian/qubes-vm-recommended.substvars; \
+	else \
+		echo "pulse:Depends=pulseaudio-qubes" >> debian/qubes-vm-recommended.substvars; \
+	fi
+	dh_gencontrol


### PR DESCRIPTION
Do not patch debian/control before the build, because it results in
orig.tar.gz being different for different Debian versions, and reprepro
is very much not happy about it (the repository has a single orig.tar.gz
for all Debian versions).
Instead, use dynamic variables generated in debian/rules.
Added benefit is that the logic is now in a single place, not duplicated
in Makefile.builder and .qubesbuilder.