### PR TITLE
Support arbitrary notification daemons

### DIFF
--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -31,7 +31,7 @@ This package depends on packages required to be installed in Qubes VM.
 
 %package -n qubes-vm-recommended
 Summary:    Meta package with packages recommended in Qubes VM
-Requires:   xfce4-notifyd
+Requires:   desktop-notification-daemon
 Requires:   pulseaudio-daemon
 Requires:   (pipewire-qubes if pipewire-pulseaudio)
 Requires:   (pulseaudio-qubes if pulseaudio)
@@ -52,6 +52,7 @@ Requires:   fwupd-qubes-vm
 %if ! (0%{?rhel} && 0%{?rhel} <= 8)
 Requires:   qubes-pdf-converter
 %endif
+Recommends: xfce4-notifyd
 
 %description -n qubes-vm-recommended
 Installing this package is recommended to have full functionality available in


### PR DESCRIPTION
Qubes OS only recomments that _a_ notification daemon be present, not that specifically xfce4-notifyd is present.  Having multiple notification daemons installed leads to problems.  Instead, require the desktop-notification-daemon capability, which is provided by multiple notification daemons.  This allows using an alternate notification daemon, such as a Qubes-specific one currently in development.

Fixes: QubesOS/qubes-issues#8729