### PR TITLE
rpm: restore empty %files section

### DIFF
--- a/rpm_spec/qubes-dom0-meta-packages.spec.in
+++ b/rpm_spec/qubes-dom0-meta-packages.spec.in
@@ -40,6 +40,8 @@ Conflicts or dummy provides packages that are not wanted in dom0.
 # contrib repo
 make -C repos install-dom0 DESTDIR=$RPM_BUILD_ROOT
 
+%files
+
 %files -n qubes-repo-contrib
 %config(noreplace) /etc/yum.repos.d/qubes-contrib-dom0-r4.2.repo
 /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4.2-contrib-fedora

--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -91,6 +91,8 @@ This package depends on packages required to be installed in a GuiVM.
 # contrib repo
 make -C repos install-vm-%{local_dist_name} DESTDIR=$RPM_BUILD_ROOT
 
+%files
+
 %files -n qubes-repo-contrib
 %config(noreplace) /etc/yum.repos.d/qubes-contrib-vm-r4.2.repo
 /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4.2-contrib-%{local_dist_name}


### PR DESCRIPTION
Not having %files makes rpm-build not build the package at all. The
point of meta-package is to still be built, but without any files. So,
restore empty %files section.