### PR TITLE
arch: move pipewire-qubes from dependencies to recommended

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -12,11 +12,12 @@ source=("${_pkgnvr}.tar.gz")
 sha256sums=(SKIP)
 
 package_qubes-vm-dependencies() {
-    depends=(qubes-vm-xen qubes-vm-core qubes-vm-qrexec qubes-vm-gui pipewire-qubes)
+    depends=(qubes-vm-xen qubes-vm-core qubes-vm-qrexec qubes-vm-gui)
 }
 
 package_qubes-vm-recommended() {
     depends=(
+        pipewire-qubes
         qubes-vm-passwordless-root
         qubes-vm-networking
         qubes-gpg-split


### PR DESCRIPTION
- audio not necessary for minimal
- matches debian and fedora