### PR TITLE
vm-recommended: relax dependency on qubes-pdf-converter

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -22,6 +22,8 @@ package_qubes-vm-recommended() {
         qubes-vm-networking
         qubes-gpg-split
         qubes-usb-proxy
+    )
+    optdepends=(
         qubes-pdf-converter
     )
 }

--- a/debian/control
+++ b/debian/control
@@ -42,9 +42,10 @@ Depends:
     qubes-img-converter,
     qubes-input-proxy-sender,
     ${qubessalt:Depends},
-    qubes-pdf-converter,
     qubes-usb-proxy,
     fwupd-qubes-vm,
+Recommends:
+    qubes-pdf-converter
 Description: Meta package with packages recommended in Qubes VM
  Installing this package is recommended to have full functionality available in
  Qubes VM.

--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -50,7 +50,7 @@ Requires:   fwupd-qubes-vm
 # qubes-pdf-converter needs python3.7+ currently
 # not fully available
 %if ! (0%{?rhel} && 0%{?rhel} <= 8)
-Requires:   qubes-pdf-converter
+Requires:   (qubes-pdf-converter if nautilus)
 %endif
 
 %description -n qubes-vm-recommended


### PR DESCRIPTION
Issue:

`qubes-pdf-converter` depends on gvfs via nautilus
  - pulls in a desktop dependencies that aren't relevant for non-gui templates and enables file-system indexing agent


---
- `qubes-vm-recommended`
  - arch: move `qubes-pdf-converter` to `optdepends`
    - #76 
  - debian: move `qubes-pdf-converter` to `Recommends`
    - `nautilus-agent` already dependency so that would need to be dropped for removal to be meaningful and obv still relevant recommendation for workstation qubes
  - fedora: optionally require `qubes-pdf-converter` if `nautilus` is enabled