### PR TITLE
arch(vm-recommended): make pipewire-qubes optional

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -12,7 +12,12 @@ source=("${_pkgnvr}.tar.gz")
 sha256sums=(SKIP)
 
 package_qubes-vm-dependencies() {
-    depends=(qubes-vm-xen qubes-vm-core qubes-vm-qrexec qubes-vm-gui)
+    depends=(
+      qubes-vm-core
+      qubes-vm-gui
+      qubes-vm-qrexec
+      qubes-vm-xen
+    )
 }
 
 package_qubes-vm-recommended() {
@@ -20,11 +25,11 @@ package_qubes-vm-recommended() {
         pipewire-qubes
     )
     depends=(
-        qubes-vm-passwordless-root
-        qubes-vm-networking
         qubes-gpg-split
-        qubes-usb-proxy
         qubes-pdf-converter
+        qubes-usb-proxy
+        qubes-vm-networking
+        qubes-vm-passwordless-root
     )
 }
 

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -16,8 +16,10 @@ package_qubes-vm-dependencies() {
 }
 
 package_qubes-vm-recommended() {
-    depends=(
+    optdepends=(
         pipewire-qubes
+    )
+    depends=(
         qubes-vm-passwordless-root
         qubes-vm-networking
         qubes-gpg-split


### PR DESCRIPTION
For Debian and Fedora, the dependency is optional depending on pulseaudio / pipewire-pulseaudio.

In archlinux, it's an unconditional hard dependency.,

This moves it to an optional dependency on arch linux.

Follow-up to #77 