### PR TITLE
add core-admin-client as a dependency for backups

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,6 +44,7 @@ Depends:
     qubes-core-agent-network-manager,
     qubes-core-agent-networking,
     qubes-core-agent-passwordless-root,
+    qubes-core-admin-client,
     qubes-gpg-split,
     qubes-img-converter,
     qubes-input-proxy-sender,

--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -41,6 +41,7 @@ Requires:   (qubes-core-agent-thunar if Thunar)
 Requires:   (qubes-core-agent-network-manager if NetworkManager)
 Requires:   qubes-core-agent-networking
 Requires:   qubes-core-agent-passwordless-root
+Requires:   qubes-core-admin-client
 Requires:   qubes-gpg-split
 Requires:   qubes-img-converter
 Requires:   qubes-input-proxy-sender


### PR DESCRIPTION
Attempt to close https://github.com/QubesOS/qubes-issues/issues/9551

If that's not the proper way, please advise.